### PR TITLE
revert test workflow triggers change

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,5 @@
 name: '🧪 Run Tests'
-on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
# Why & How

This small PR reverts the test workflow triggers change, unfortunately on push to `main` action lacks the context for checks.