### PR TITLE
[fix] find appropriate entry line by string match instead of index

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,10 +78,14 @@ const constructClassicEntry = entryLines => {
       )
     : undefined;
 
+  const version = entryLines.find(line => line.includes('version ')).split('version ')[1];
+  const resolved = entryLines.find(line => line.includes('resolved ')).split('resolved ')[1];
+  const integrity = entryLines.find(line => line.includes('integrity ')).split('integrity ')[1];
+
   const entryObject = {
-    version: entryLines[1].split('version ')[1],
-    resolved: entryLines[2].split('resolved ')[1],
-    integrity: entryLines[3].split('integrity ')[1],
+    version,
+    resolved,
+    integrity,
     dependencies
   };
 


### PR DESCRIPTION
Ran into this issue where one entry in our `yarn.lock` for some reason has `name` as a field. This was resulting in the following error during runtime 

```
    TypeError: Invalid version. Must be a string. Got type "undefined".
```

```
"@swc/helpers@^0.4.14":
  name legacy-swc-helpers
  version "0.4.14"
  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
  dependencies:
    tslib "^2.4.0"
```