### PR TITLE
add `name` field to the test locks, fix remaining issues

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,18 +78,19 @@ const constructClassicEntry = entryLines => {
       )
     : undefined;
 
-  const version = entryLines.find(line => line.includes('version ')).split('version ')[1];
-  const resolved = entryLines.find(line => line.includes('resolved ')).split('resolved ')[1];
-  const integrity = entryLines.find(line => line.includes('integrity ')).split('integrity ')[1];
-
   const entryObject = {
-    version,
-    resolved,
-    integrity,
+    version: findLockLineValue(entryLines, 'version'),
+    resolved: findLockLineValue(entryLines, 'resolved'),
+    integrity: findLockLineValue(entryLines, 'integrity'),
     dependencies
   };
 
   return Object.assign({}, ...keys.map(key => ({ [key.trim()]: entryObject })));
+};
+
+const findLockLineValue = (lines, keyString) => {
+  const foundLine = lines.find(line => line.includes(`${keyString} `));
+  return foundLine ? foundLine.split(`${keyString} `)[1] : undefined;
 };
 
 const constructBerryEntry = entryLines => {
@@ -100,7 +101,7 @@ const constructBerryEntry = entryLines => {
     .replaceAll(':', '')
     .split(',');
 
-  const version = entryLines[1].split('version: ')[1];
+  const version = findLockLineValue(entryLines, 'version:');
   const isLocal = version.includes('use.local');
 
   const endFields = entryLines.splice(isLocal ? -3 : -4);
@@ -108,9 +109,11 @@ const constructBerryEntry = entryLines => {
   const peerFields =
     peerBlockStart !== -1 ? entryLines.splice(-(entryLines.length - peerBlockStart)) : undefined;
 
-  const dependencies = entryLines[3]?.includes('dependencies:')
-    ? Object.assign({}, ...entryLines.splice(4).map(parseDependencyLine))
-    : undefined;
+  const dependenciesBlockStart = entryLines.findIndex(entry => entry.includes('dependencies:'));
+  const dependencies =
+    dependenciesBlockStart !== -1
+      ? Object.assign({}, ...entryLines.splice(4).map(parseDependencyLine))
+      : undefined;
 
   const peerBlockEnd =
     peerFields && peerFields.findIndex(entry => entry.includes('peerDependenciesMeta:'));
@@ -123,7 +126,7 @@ const constructBerryEntry = entryLines => {
       : undefined;
 
   const integrity = !isLocal && endFields[0].split('checksum: ')[1];
-  const resolution = entryLines[2].split('resolution: ')[1];
+  const resolution = findLockLineValue(entryLines, 'resolution:');
 
   const entryObject = {
     version,

--- a/tests/unit/berry-v2/a.lock
+++ b/tests/unit/berry-v2/a.lock
@@ -25,6 +25,7 @@ __metadata:
   linkType: hard
 
 "@actions/http-client@npm:^2.0.1":
+  name: legacy-http-client
   version: 2.0.1
   resolution: "@actions/http-client@npm:2.0.1"
   dependencies:

--- a/tests/unit/berry-v3/a.lock
+++ b/tests/unit/berry-v3/a.lock
@@ -25,6 +25,7 @@ __metadata:
   linkType: hard
 
 "@actions/http-client@npm:^2.0.1":
+  name: legacy-http-client
   version: 2.0.1
   resolution: "@actions/http-client@npm:2.0.1"
   dependencies:


### PR DESCRIPTION
# Why & How

Refs #67 

Add `name` field to the unit test locks, fix remaining issues in parser with finding the correct lines, which leads to test failures.