### PR TITLE
switch to Node 20 as default runner, test also 18 and 20 on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,17 @@ on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16, 18, 20]
+    name: Testing on Node ${{ matrix.node }}
     steps:
     - name: '🚚 Checkout'
       uses: actions/checkout@v3
     - name: '🔧 Setup Node'
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: ${{ matrix.node }}
     - name: '📦️ Install dependencies'
       run: yarn
     - name: '🧪 Run Unit tests'

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# Why & how

The newest [`@actions/github` release](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md#600) has dropped the Node 14 and 16 support, so in the future action version those engines would need to dropped to, but for now let's just test and run by default on newer Node versions, and announce future Node drops for the action users in the upcoming bugfix release.