### PR TITLE
update yarn and lodash in CI tests

### DIFF
--- a/tests/ci/berry-v2/package.json
+++ b/tests/ci/berry-v2/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "lodash": "^4.17.23"
+    "lodash": "^4.18.1"
   },
   "packageManager": "yarn@2.4.3"
 }

--- a/tests/ci/berry-v2/yarn.lock
+++ b/tests/ci/berry-v2/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 4
   cacheKey: 7
 
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 4f617568d9a177e64da80135481a408d2a5a8e2b45a4d5c020bdcdedeb662664b4990e1cef8f08d13d3da042c63fc2c7b80fb2953fd30845d5d5337d7089dea2
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 53010951126731ba374c7f4ad513103f91b16c71f19acf606587647d551df5f645e5e3faeadc20f4e01be468ed4e6fb196121315fc0c0d98dfc51293a78bd223
   languageName: node
   linkType: hard
 
@@ -16,6 +16,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    lodash: ^4.17.23
+    lodash: ^4.18.1
   languageName: unknown
   linkType: soft

--- a/tests/ci/berry-v3/package.json
+++ b/tests/ci/berry-v3/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "lodash": "^4.17.23"
+    "lodash": "^4.18.1"
   },
-  "packageManager": "yarn@3.4.1"
+  "packageManager": "yarn@3.8.7"
 }

--- a/tests/ci/berry-v3/yarn.lock
+++ b/tests/ci/berry-v3/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 
@@ -16,6 +16,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    lodash: ^4.17.23
+    lodash: ^4.18.1
   languageName: unknown
   linkType: soft

--- a/tests/ci/berry-v4/package.json
+++ b/tests/ci/berry-v4/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "lodash": "^4.17.23"
+    "lodash": "^4.18.1"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.13.0"
 }

--- a/tests/ci/berry-v4/yarn.lock
+++ b/tests/ci/berry-v4/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 
@@ -16,6 +16,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    lodash: "npm:^4.17.23"
+    lodash: "npm:^4.18.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# How

Address dependabot warning caused by CI tests, bump used yarn version to latest.