### PR TITLE
update yarn and lodash in classic CI test

### DIFF
--- a/tests/ci/classic/package.json
+++ b/tests/ci/classic/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "lodash": "^4.17.23"
+    "lodash": "^4.18.1"
   }
 }

--- a/tests/ci/classic/yarn.lock
+++ b/tests/ci/classic/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-lodash@^4.17.23:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
# How

Update yarn classic CI test to avoid dependabot warnings.